### PR TITLE
Node v4 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
+  - '4'

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ For instance, you should be able to use most (all?) of the jQuery API after you'
 
 ### Versioning
 
-This library intentionally depends on an old version of JSDom, v3.0, as this is the last version
-of JSDom to support Node. Newer versions are for io.js only. Most developers use Node,
-so it doesn't make sense to upgrade.
+This library requires Node v4+ and JSDom v7+.
 
 ### API
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var jsdom = require('jsdom').jsdom;
 var document = jsdom('<html><head></head><body></body></html>');
-var window = document.parentWindow;
+var window = document.defaultView;
 var navigator = window.navigator = {
   userAgent: 'NodeJS JSDom',
   appVersion: ''

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   },
   "homepage": "https://github.com/jmeas/simple-jsdom#readme",
   "dependencies": {
-    "jsdom": "^3.1.2"
+    "jsdom": "^7.0.2"
   },
   "devDependencies": {
-    "mocha": "^2.2.5"
-  }
+    "mocha": "^2.3.3"
+  },
+  "engine": "node >= 4.0.0"
 }


### PR DESCRIPTION
Resolve #5 

This updates JSDom to v7 and requires Node v4+.

I'm not sure there's a good way to support legacy node / JSDom and the new stuff.
